### PR TITLE
 fix: check nvim__exec_lua_fast using version 

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -149,7 +149,11 @@ async fn launch(
         settings.set::<WindowSettings>(&window_settings);
     }
 
-    let can_support_ime_api = api_information.has_function("nvim__exec_lua_fast");
+    // NOTE: `api_information.has_function("nvim__exec_lua_fast")` does not return the correct
+    // result so we check the version instead.
+    let can_support_ime_api = api_information
+        .version
+        .has_version(0, 12, 0, Some(1724));
 
     start_ui_command_handler(
         session.neovim.clone(),

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -82,7 +82,9 @@ impl SerialCommand {
                         ],
                     )
                     .await
-                    .map(|_| ())
+                    .map(|_| {
+                        trace!("IME Commit Called");
+                    })
                     .context("IME Commit failed")
                 } else {
                     trace!("Keyboard Input Sent: {formatted}");
@@ -108,7 +110,9 @@ impl SerialCommand {
                         ],
                     )
                     .await
-                    .map(|_| ())
+                    .map(|_| {
+                        trace!("IME Preedit Called");
+                    })
                     .context("IME Preedit failed")
                 } else {
                     Ok(())


### PR DESCRIPTION
`.has_function("nvim__exec_lua_fast")` always returned false, thus I changed the way to check if that function is available.

## What kind of change does this PR introduce?
- Fix


## Did this PR introduce a breaking change? 
- No
